### PR TITLE
Make it possible to override webpack compiled config with an assets/config.json file.

### DIFF
--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NavigationHelperService } from "../shared/navigation-helper.service";
+import { AppConfig } from '../app.config';
 
 @Component({
   selector: 'about',
@@ -8,7 +9,7 @@ import { NavigationHelperService } from "../shared/navigation-helper.service";
 })
 
 export class AboutComponent implements OnInit {
-	public environment = ENVIRONMENT_TEXT;
+	public environment = AppConfig.ENVIRONMENT_TEXT;
   constructor(private navigationHelper: NavigationHelperService) {
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { layoutPaths } from './theme/theme.constants';
 import {MCNotificationsService, NotificationModel, MCNotificationType} from "./shared/mc-notifications.service";
 import {NotificationsService} from "angular2-notifications";
 import {NavigationStart, Router} from "@angular/router";
+import { AppConfig } from './app.config';
 
 /*
  * App Component
@@ -59,6 +60,11 @@ export class App {
     BaThemePreloader.load().then((values) => {
       this._spinner.hide();
     });
+    
+    if (AppConfig.ENVIRONMENT_TEXT != '') {
+      document.body.classList.add('test-banner');
+      document.body.setAttribute('data-title', AppConfig.ENVIRONMENT_TEXT);
+    }
   }
 
   private _loadImages(): void {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,0 +1,35 @@
+declare const fetch: Function
+
+export class AppConfig {
+  static KEYCLOAK_JSON: string;
+  static ENDORSEMENT_BASE_PATH: string;
+  static IR_BASE_PATH: string;
+  static SR_BASE_PATH: string;
+  static ENVIRONMENT_TEXT: string;
+  static IDP_NAMESPACE: string;
+
+  public static _initialize() {
+    return fetch('/assets/config.json')
+      .then(response => response.json())
+      .then( config => {
+        AppConfig.IR_BASE_PATH = config.irBasePath
+        AppConfig.SR_BASE_PATH = config.srBasePath
+        AppConfig.ENDORSEMENT_BASE_PATH = config.endorsementBasePath
+        AppConfig.KEYCLOAK_JSON = config.keycloakJson
+        AppConfig.ENVIRONMENT_TEXT = config.environmentText
+        AppConfig.IDP_NAMESPACE = config.idpNamespace
+        return;
+      })
+      .catch(function (error) { 
+        console.log("No config.json file could be loaded: " + error); 
+        AppConfig.IR_BASE_PATH = IR_BASE_PATH
+        AppConfig.SR_BASE_PATH = SR_BASE_PATH
+        AppConfig.ENDORSEMENT_BASE_PATH = ENDORSEMENT_BASE_PATH;
+        AppConfig.KEYCLOAK_JSON = KEYCLOAK_JSON;
+        AppConfig.ENVIRONMENT_TEXT = ENVIRONMENT_TEXT;
+        AppConfig.IDP_NAMESPACE = IDP_NAMESPACE;
+        return;
+      });
+  }
+}
+AppConfig._initialize();

--- a/src/app/apply-org/apply-org.component.ts
+++ b/src/app/apply-org/apply-org.component.ts
@@ -16,6 +16,7 @@ import {
 	McFormControlType, McFormControlModelCheckbox
 } from "../theme/components/mcForm/mcFormControlModel";
 import {CheckboxValidator} from "../theme/validators/checkbox.validator";
+import { AppConfig } from '../app.config';
 
 @Component({
   selector: 'apply-org',
@@ -47,8 +48,8 @@ export class ApplyOrgComponent implements OnInit {
 
   ngOnInit() {
   	if (!CAN_JOIN) {
-		  this.notificationService.generateNotification('Apply', 'You can only apply in production. This is ' + ENVIRONMENT_TEXT, MCNotificationType.Alert);
-		  this.navigationHelper.takeMeHome();
+		this.notificationService.generateNotification('Apply', 'You can only apply in production. This is ' + AppConfig.ENVIRONMENT_TEXT, MCNotificationType.Alert);
+		this.navigationHelper.takeMeHome();
   		return;
 	  }
 	  this.calculateClass();

--- a/src/app/authentication/services/auth.service.ts
+++ b/src/app/authentication/services/auth.service.ts
@@ -4,7 +4,7 @@ import {MCNotificationsService, MCNotificationType} from "../../shared/mc-notifi
 import {Role} from "../../backend-api/identity-registry/autogen/model/Role";
 import RoleNameEnum = Role.RoleNameEnum;
 import {User} from "../../backend-api/identity-registry/autogen/model/User";
-
+import { AppConfig } from '../../app.config';
 
 export enum AuthPermission {
 	User    = 1 << 0,
@@ -184,7 +184,7 @@ export class AuthService implements OnInit {
   }
 
   static init(): Promise<any> {
-    let keycloakAuth: any = new Keycloak(KEYCLOAK_JSON);
+    let keycloakAuth: any = new Keycloak(AppConfig.KEYCLOAK_JSON);
     AuthService.staticAuthInfo.loggedIn = false;
 
     return new Promise((resolve, reject) => {

--- a/src/app/backend-api/endorsements/endorsement-api.module.ts
+++ b/src/app/backend-api/endorsements/endorsement-api.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {Http} from "@angular/http";
 import {EndorsecontrollerApi} from "./autogen/api/EndorsecontrollerApi";
+import { AppConfig } from '../../app.config';
+
 
 @NgModule({
   imports: [
@@ -13,7 +15,7 @@ import {EndorsecontrollerApi} from "./autogen/api/EndorsecontrollerApi";
 	  {
 		  provide: EndorsecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new EndorsecontrollerApi(http, ENDORSEMENT_BASE_PATH, null);
+			  return new EndorsecontrollerApi(http, AppConfig.ENDORSEMENT_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  }

--- a/src/app/backend-api/identity-registry/identity-registry-api.module.ts
+++ b/src/app/backend-api/identity-registry/identity-registry-api.module.ts
@@ -11,6 +11,7 @@ import {Http} from "@angular/http";
 import {BugReportControllerApi} from "./autogen/api/BugReportControllerApi";
 import {VesselimagecontrollerApi} from "./autogen/api/VesselimagecontrollerApi";
 import { AgentControllerService } from './autogen/api/agentController.service';
+import { AppConfig } from '../../app.config';
 
 @NgModule({
   imports: [
@@ -22,77 +23,77 @@ import { AgentControllerService } from './autogen/api/agentController.service';
 	  {
 		  provide: BugReportControllerApi,
 		  useFactory: (http: Http) => {
-			  return new BugReportControllerApi(http, IR_BASE_PATH);
-		  },
+			return new BugReportControllerApi(http, AppConfig.IR_BASE_PATH);
+		},
 		  deps: [Http]
 	  },
 	  {
 		  provide: RolecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new RolecontrollerApi(http, IR_BASE_PATH, null);
+			  return new RolecontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: ServicecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new ServicecontrollerApi(http, IR_BASE_PATH, null);
+			  return new ServicecontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: OrganizationcontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new OrganizationcontrollerApi(http, IR_BASE_PATH, null);
+			  return new OrganizationcontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: LogocontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new LogocontrollerApi(http, IR_BASE_PATH, null);
+			  return new LogocontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: VesselcontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new VesselcontrollerApi(http, IR_BASE_PATH, null);
+			  return new VesselcontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: UsercontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new UsercontrollerApi(http, IR_BASE_PATH, null);
+			  return new UsercontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: ServicecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new ServicecontrollerApi(http, IR_BASE_PATH, null);
+			  return new ServicecontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: DevicecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new DevicecontrollerApi(http, IR_BASE_PATH, null);
+			  return new DevicecontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: VesselimagecontrollerApi,
 		  useFactory: (http: Http) => {
-			  return new VesselimagecontrollerApi(http, IR_BASE_PATH, null);
+			  return new VesselimagecontrollerApi(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: AgentControllerService,
 		  useFactory: (http: Http) => {
-			return new AgentControllerService(http, IR_BASE_PATH, null);
+			return new AgentControllerService(http, AppConfig.IR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  }

--- a/src/app/backend-api/identity-registry/services/bug-reporting.service.ts
+++ b/src/app/backend-api/identity-registry/services/bug-reporting.service.ts
@@ -6,6 +6,7 @@ import {BugReport} from "../autogen/model/BugReport";
 import {McHttpService} from "../../shared/mc-http.service";
 import {AuthService, AuthUser} from "../../../authentication/services/auth.service";
 import {BugReportControllerApi} from "../autogen/api/BugReportControllerApi";
+import { AppConfig } from '../../../app.config';
 
 @Injectable()
 export class BugReportingService {
@@ -15,8 +16,8 @@ export class BugReportingService {
   }
 
   public reportBug(bugReport:BugReport) : Observable<any> {
-		bugReport.subject = "#"+ ENVIRONMENT_TEXT + ' v.' + this.version + ': ' + bugReport.subject;
-  	if (AuthService.staticAuthInfo && AuthService.staticAuthInfo.loggedIn) {
+	bugReport.subject = "#"+ AppConfig.ENVIRONMENT_TEXT + ' v.' + this.version + ': ' + bugReport.subject;
+	if (AuthService.staticAuthInfo && AuthService.staticAuthInfo.loggedIn) {
   		this.addUserToReport(bugReport, AuthService.staticAuthInfo.user);
 	  }
 	  McHttpService.nextCallShouldNotAuthenticate();

--- a/src/app/backend-api/service-registry/service-registry-api.module.ts
+++ b/src/app/backend-api/service-registry/service-registry-api.module.ts
@@ -10,6 +10,7 @@ import {XsdresourceApi} from "./autogen/api/XsdresourceApi";
 import {InstanceXmlParser} from "../../pages/org-service-registry/shared/services/instance-xml-parser.service";
 import {DesignXmlParser} from "../../pages/org-service-registry/shared/services/design-xml-parser.service";
 import {SpecificationXmlParser} from "../../pages/org-service-registry/shared/services/specification-xml-parser.service";
+import { AppConfig } from '../../app.config';
 
 @NgModule({
   imports: [
@@ -22,42 +23,42 @@ import {SpecificationXmlParser} from "../../pages/org-service-registry/shared/se
 	  {
 		  provide: ServicespecificationresourceApi,
 		  useFactory: (http: Http) => {
-			  return new ServicespecificationresourceApi(http, SR_BASE_PATH, null);
+			  return new ServicespecificationresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: ServiceinstanceresourceApi,
 		  useFactory: (http: Http) => {
-			  return new ServiceinstanceresourceApi(http, SR_BASE_PATH, null);
+			  return new ServiceinstanceresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: TechnicaldesignresourceApi,
 		  useFactory: (http: Http) => {
-			  return new TechnicaldesignresourceApi(http, SR_BASE_PATH, null);
+			  return new TechnicaldesignresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: XmlresourceApi,
 		  useFactory: (http: Http) => {
-			  return new XmlresourceApi(http, SR_BASE_PATH, null);
+			  return new XmlresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: DocresourceApi,
 		  useFactory: (http: Http) => {
-			  return new DocresourceApi(http, SR_BASE_PATH, null);
+			  return new DocresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },
 	  {
 		  provide: XsdresourceApi,
 		  useFactory: (http: Http) => {
-			  return new XsdresourceApi(http, SR_BASE_PATH, null);
+			  return new XsdresourceApi(http, AppConfig.SR_BASE_PATH, null);
 		  },
 		  deps: [Http]
 	  },

--- a/src/app/backend-api/shared/api-version.service.ts
+++ b/src/app/backend-api/shared/api-version.service.ts
@@ -12,6 +12,7 @@ import {
 } from "@angular/http";
 import { McHttpService } from "./mc-http.service";
 import { ServerUnreachableError } from "../../shared/ServerUnreachableError";
+import { AppConfig } from '../../app.config';
 
 @Injectable()
 export class ApiVersionService {
@@ -20,17 +21,17 @@ export class ApiVersionService {
   }
 
 	public getVersionOfIdentityRegistry():Observable<string> {
-		let jsonLocation =  IR_BASE_PATH + MIR_SWAGGER_LOCATION;
+		let jsonLocation =  AppConfig.IR_BASE_PATH + MIR_SWAGGER_LOCATION;
 		return this.getVersionFromSwagger(jsonLocation);
 	}
 
 	public getVersionOfServiceRegistry():Observable<string> {
-		let jsonLocation =  SR_BASE_PATH + SWAGGER_LOCATION;
+		let jsonLocation =  AppConfig.SR_BASE_PATH + SWAGGER_LOCATION;
 		return this.getVersionFromSwagger(jsonLocation);
 	}
 
 	public getVersionOfEndorsementService(): Observable<string> {
-  		let jsonLocation = ENDORSEMENT_BASE_PATH + SWAGGER_LOCATION;
+  		let jsonLocation = AppConfig.ENDORSEMENT_BASE_PATH + SWAGGER_LOCATION;
   		return this.getVersionFromSwagger(jsonLocation);
 	}
 

--- a/src/app/shared/mrn-helper.service.ts
+++ b/src/app/shared/mrn-helper.service.ts
@@ -1,10 +1,11 @@
 import {Injectable} from "@angular/core";
 import {AuthService} from "../authentication/services/auth.service";
+import { AppConfig } from '../app.config';
 
 // TODO this is only a temp solution until there is a backend service to do it
 @Injectable()
 export class MrnHelperService {
-	private idpNamespace = IDP_NAMESPACE;
+	private idpNamespace = AppConfig.IDP_NAMESPACE;
 	public mrnMCP: string = 'urn:mrn:mcp:';
 
 	constructor(private authService: AuthService) {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,0 +1,8 @@
+{
+    "irBasePath": "https://api.navelink.local",
+    "srBasePath": "https://serviceregistry.navelink.local",
+    "endorsementBasePath": "https://endorse.navelink.local",
+    "keycloakJson": "assets/keycloak.json",
+    "environmentText": "LOCAL",
+    "idpNamespace": "navelink-local"
+}

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -1,8 +1,0 @@
-{
-    "irBasePath": "https://api.navelink.local",
-    "srBasePath": "https://serviceregistry.navelink.local",
-    "endorsementBasePath": "https://endorse.navelink.local",
-    "keycloakJson": "assets/keycloak.json",
-    "environmentText": "LOCAL",
-    "idpNamespace": "navelink-local"
-}

--- a/src/assets/test-config.json
+++ b/src/assets/test-config.json
@@ -1,0 +1,8 @@
+{
+    "irBasePath": "https://test-api.maritimeconnectivity.net",
+    "srBasePath": "https://sr-test.maritimeconnectivity.net",
+    "endorsementBasePath": "https://test-endorse.maritimeconnectivity.net",
+    "keycloakJson": "assets/test-keycloak.json",
+    "environmentText": "TEST",
+    "idpNamespace": "mcc-test"
+}

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -10,12 +10,15 @@ import { bootloader } from '@angularclass/hmr';
  */
 import { AppModule } from './app';
 import {AuthService} from "./app/authentication/services/auth.service";
+import { AppConfig } from './app/app.config';
 
 /*
  * Bootstrap our Angular app with a top level NgModule
  */
 export function main(): Promise<any> {
-  return AuthService.init()
+
+  return AppConfig._initialize()
+    .then(() => AuthService.init())
     .then(() => {
       const platform = platformBrowserDynamic();
       platform.bootstrapModule(AppModule);


### PR DESCRIPTION
Added code to load config strings from assets/config.json on the server at app load time to override the constants compiled into files by webpack at build time.
This makes it easier to build the portal TS code once and then reuse the same build i.e. in a container image where the assets/config.json file can be added as a container configured file/volume. Makes it possible to really run the exact same code in dev/test/production environments without rebuilding for each environment. 